### PR TITLE
Fix imu data

### DIFF
--- a/src/ros_whill.cpp
+++ b/src/ros_whill.cpp
@@ -304,13 +304,13 @@ void whill_callback_data1(WHILL *caller)
 
     imu.orientation_covariance[0] = -1; // Orientation is unknown
 
-    imu.angular_velocity.x = caller->gyro.x / 180 * M_PI; // deg per sec to rad/s
-    imu.angular_velocity.y = caller->gyro.y / 180 * M_PI; // deg per sec to rad/s
-    imu.angular_velocity.z = caller->gyro.z / 180 * M_PI; // deg per sec to rad/s
+    imu.angular_velocity.x = caller->gyro.x / 65535.0 * 500.0 / 180.0 * M_PI; // deg per sec to rad/s
+    imu.angular_velocity.y = caller->gyro.y / 65535.0 * 500.0 / 180.0 * M_PI; // deg per sec to rad/s
+    imu.angular_velocity.z = caller->gyro.z / 65535.0 * 500.0 / 180.0 * M_PI; // deg per sec to rad/s
 
-    imu.linear_acceleration.x = caller->accelerometer.x * 9.80665; // G to m/ss
-    imu.linear_acceleration.y = caller->accelerometer.y * 9.80665; // G to m/ssnav_msgs::Odometry odom_msg = odom.getROSOdometry();
-    imu.linear_acceleration.z = caller->accelerometer.z * 9.80665; // G to m/ss
+    imu.linear_acceleration.x = caller->accelerometer.x / 65535.0 * 8.0 * 9.80665; // G to m/ss
+    imu.linear_acceleration.y = caller->accelerometer.y / 65535.0 * 8.0 * 9.80665; // G to m/ssnav_msgs::Odometry odom_msg = odom.getROSOdometry();
+    imu.linear_acceleration.z = caller->accelerometer.z / 65535.0 * 8.0 * 9.80665; // G to m/ss
     ros_imu_publisher.publish(imu);
 
     // Battery


### PR DESCRIPTION
The IMU data is disabled in the latest version because it is not reliable.  #28 
However, the IMU data sent from WHILL is the raw IMU data, not the degree per sec. Therefore, the correct value can be obtained by calculating according to the resolution.
[IMU datasheet](https://docs.rs-online.com/f50f/0900766b814da08b.pdf)

IMU topic after fixation
```
header: 
  seq: 668
  stamp: 
    secs: 1636746109
    nsecs: 851973746
  frame_id: "imu"
orientation: 
  x: 0.0
  y: 0.0
  z: 0.0
  w: 0.0
orientation_covariance: [-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
angular_velocity: 
  x: 0.03861642504603308
  y: -0.15885998303419815
  z: -0.08349137415125084
angular_velocity_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
linear_acceleration: 
  x: 7.411364327458609
  y: 0.0323222156099794
  z: -6.41176988174258
linear_acceleration_covariance: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
```

When this acceleration data is converted to acceleration at base_link, it looks like this. We can see that the gravitational acceleration is correctly observed and the IMU is functioning properly.

```
header: 
  seq: 61805
  stamp: 
    secs: 1636743368
    nsecs: 570296019
  frame_id: "base_link"
orientation: 
  x: 0.0
  y: 0.0
  z: 0.0
  w: 0.0
orientation_covariance: [0.0, 0.0, 0.0, -0.0, 0.0, 0.0, -0.0, 0.0, 0.0]
angular_velocity: 
  x: 0.040097561229167966
  y: 0.1577947023432809
  z: -0.08478847122633333
angular_velocity_covariance: [0.0, 0.0, 0.0, -0.0, 0.0, 0.0, -0.0, 0.0, 0.0]
linear_acceleration: 
  x: 0.03595979966291285
  y: 0.004788476388188037
  z: -9.797482665167069
linear_acceleration_covariance: [0.0, 0.0, 0.0, -0.0, 0.0, 0.0, -0.0, 0.0, 0.0]

```

IMU is disabled in the latest version, but can it be re-enabled?